### PR TITLE
Persist user settings and use real surf forecast

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,63 +3,48 @@ const surfSpots = {
     'ocean-beach': {
         name: 'Ocean Beach',
         description: 'The Main Break - Heavy and Hollow',
-        characteristics: {
-            grom: { minWave: 2, maxWave: 4, bestTide: 'mid', bestWind: 'offshore' },
-            intermediate: { minWave: 4, maxWave: 8, bestTide: 'low-mid', bestWind: 'offshore' },
-            ripper: { minWave: 6, maxWave: 15, bestTide: 'low', bestWind: 'offshore' }
-        },
         crowdFactor: 'heavy',
-        vibe: 'Gnarly paddle-outs, serious juice'
+        vibe: 'Gnarly paddle-outs, serious juice',
+        lat: 37.760,
+        lon: -122.513
     },
     'pacifica': {
         name: 'Pacifica / Linda Mar',
         description: 'The Mellow Zone - Perfect for Learning',
-        characteristics: {
-            grom: { minWave: 1, maxWave: 3, bestTide: 'all', bestWind: 'light' },
-            intermediate: { minWave: 2, maxWave: 5, bestTide: 'mid-high', bestWind: 'light offshore' },
-            ripper: { minWave: 3, maxWave: 6, bestTide: 'high', bestWind: 'offshore' }
-        },
         crowdFactor: 'mellow',
-        vibe: 'Friendly lineup, good vibes'
+        vibe: 'Friendly lineup, good vibes',
+        lat: 37.638,
+        lon: -122.494
     },
     'mavericks': {
         name: 'Mavericks',
         description: 'Big Wave Capital - Legends Only',
-        characteristics: {
-            grom: { minWave: 0, maxWave: 0, bestTide: 'none', bestWind: 'none' },
-            intermediate: { minWave: 0, maxWave: 0, bestTide: 'none', bestWind: 'none' },
-            ripper: { minWave: 15, maxWave: 50, bestTide: 'low', bestWind: 'offshore' }
-        },
         crowdFactor: 'invitation only',
-        vibe: 'Death-defying giants, respect required'
+        vibe: 'Death-defying giants, respect required',
+        lat: 37.493,
+        lon: -122.500
     },
     'fort-point': {
         name: 'Fort Point',
         description: 'Under the Golden Gate - Urban Shred',
-        characteristics: {
-            grom: { minWave: 2, maxWave: 4, bestTide: 'high', bestWind: 'light' },
-            intermediate: { minWave: 3, maxWave: 6, bestTide: 'mid-high', bestWind: 'west' },
-            ripper: { minWave: 4, maxWave: 10, bestTide: 'mid', bestWind: 'west' }
-        },
         crowdFactor: 'locals',
-        vibe: 'Classic left, bridge views'
+        vibe: 'Classic left, bridge views',
+        lat: 37.807,
+        lon: -122.477
     },
     'bolinas': {
         name: 'Bolinas',
         description: 'The Secret Spot - Shhh...',
-        characteristics: {
-            grom: { minWave: 2, maxWave: 4, bestTide: 'mid', bestWind: 'light' },
-            intermediate: { minWave: 3, maxWave: 7, bestTide: 'mid-low', bestWind: 'offshore' },
-            ripper: { minWave: 5, maxWave: 12, bestTide: 'low', bestWind: 'offshore' }
-        },
         crowdFactor: 'locals only',
-        vibe: 'Keep it on the down-low'
+        vibe: 'Keep it on the down-low',
+        lat: 37.906,
+        lon: -122.701
     }
 };
 
 // State management
 let userLevel = localStorage.getItem('surfLevel') || null;
-let selectedBeach = 'ocean-beach';
+let selectedBeach = localStorage.getItem('surfBeach') || 'ocean-beach';
 
 // Initialize the app
 document.addEventListener('DOMContentLoaded', () => {
@@ -72,10 +57,17 @@ function initializeApp() {
         activateSkillButton(userLevel);
         showForecast();
     }
-    
+
     // Set up event listeners
     setupEventListeners();
-    
+
+    // Restore previously selected beach
+    document.querySelectorAll('.beach-tab').forEach(tab => tab.classList.remove('active'));
+    const savedTab = document.querySelector(`[data-beach="${selectedBeach}"]`);
+    if (savedTab) {
+        savedTab.classList.add('active');
+    }
+
     // Generate initial forecast if user level exists
     if (userLevel) {
         generateForecast();
@@ -124,13 +116,14 @@ function activateSkillButton(level) {
 
 function selectBeach(beach) {
     selectedBeach = beach;
-    
+    localStorage.setItem('surfBeach', beach);
+
     // Update active tab
     document.querySelectorAll('.beach-tab').forEach(tab => {
         tab.classList.remove('active');
     });
     document.querySelector(`[data-beach="${beach}"]`).classList.add('active');
-    
+
     // Regenerate forecast for new beach
     if (userLevel) {
         generateForecast();
@@ -142,22 +135,21 @@ function showForecast() {
     forecastContainer.style.display = 'block';
 }
 
-function generateForecast() {
+async function generateForecast() {
     const forecastGrid = document.getElementById('forecast-grid');
     const spot = surfSpots[selectedBeach];
-    const characteristics = spot.characteristics[userLevel];
-    
+
     // Clear existing forecast
     forecastGrid.innerHTML = '';
-    
-    // Check if this spot is appropriate for user level
-    if (characteristics.minWave === 0 && selectedBeach === 'mavericks' && userLevel !== 'ripper') {
+
+    // Warn users away from Mavericks unless they are rippers
+    if (selectedBeach === 'mavericks' && userLevel !== 'ripper') {
         forecastGrid.innerHTML = `
             <div style="grid-column: 1 / -1; text-align: center; padding: 40px;">
-                <h3 style="color: #ff00ff; font-size: 2rem;">WHOA THERE, ${userLevel.toUpperCase()}!</h3>
+                <h3 style="color: #ff00ff; font-size: 2rem;">WHOA THERE, ${userLevel ? userLevel.toUpperCase() : 'BUDDY'}!</h3>
                 <p style="color: #ffff00; font-size: 1.2rem; margin-top: 20px;">
                     Mavericks ain't for you yet, brah. This wave will straight-up eat you for breakfast.
-                    Keep training and maybe one day you'll charge these monsters. 
+                    Keep training and maybe one day you'll charge these monsters.
                 </p>
                 <p style="color: #00ffff; margin-top: 15px;">
                     🚫 Try Ocean Beach or Pacifica instead! 🚫
@@ -166,66 +158,53 @@ function generateForecast() {
         `;
         return;
     }
-    
-    // Generate 7-day forecast
-    const days = ['Today', 'Tomorrow', 'Day 3', 'Day 4', 'Day 5', 'Day 6', 'Day 7'];
-    const conditions = ['Epic', 'Firing', 'Fair', 'Blown Out'];
-    const timeSlots = ['Dawn Patrol', 'Morning Glass', 'Midday', 'Afternoon', 'Sunset Session'];
-    
-    days.forEach((day, index) => {
-        // Generate semi-random but realistic conditions
-        const waveHeight = generateWaveHeight(characteristics, index);
-        const condition = generateCondition(waveHeight, characteristics, index);
-        const bestTime = generateBestTime(condition, index);
-        
-        const card = document.createElement('div');
-        card.className = 'forecast-card';
-        
-        card.innerHTML = `
-            <div class="day-name">${day}</div>
-            <div class="wave-height">${waveHeight.min}-${waveHeight.max}ft</div>
-            <div class="best-time">
-                <strong>Best:</strong><br>
-                ${bestTime}
-            </div>
-            <div class="conditions condition-${condition.toLowerCase().replace(' ', '-')}">
-                ${condition}
-            </div>
-        `;
-        
-        forecastGrid.appendChild(card);
-    });
+
+    try {
+        const response = await fetch(`https://marine-api.open-meteo.com/v1/marine?latitude=${spot.lat}&longitude=${spot.lon}&daily=wave_height_max&timezone=auto&forecast_days=7`);
+        const data = await response.json();
+
+        const days = data.daily.time;
+        const heights = data.daily.wave_height_max;
+
+        days.forEach((date, index) => {
+            const heightFt = (heights[index] * 3.281).toFixed(1);
+            const condition = getCondition(heightFt);
+            const bestTime = generateBestTime(condition, index);
+            const dayName = index === 0 ? 'Today' : new Date(date).toLocaleDateString(undefined, { weekday: 'long' });
+
+            const card = document.createElement('div');
+            card.className = 'forecast-card';
+
+            card.innerHTML = `
+                <div class="day-name">${dayName}</div>
+                <div class="wave-height">${heightFt}ft</div>
+                <div class="best-time">
+                    <strong>Best:</strong><br>
+                    ${bestTime}
+                </div>
+                <div class="conditions condition-${condition.toLowerCase().replace(' ', '-')}">
+                    ${condition}
+                </div>
+            `;
+
+            forecastGrid.appendChild(card);
+        });
+    } catch (err) {
+        forecastGrid.innerHTML = '<div style="grid-column: 1 / -1; text-align: center; padding: 40px;">Unable to load forecast</div>';
+        console.error(err);
+    }
 }
 
-function generateWaveHeight(characteristics, dayIndex) {
-    // Create somewhat realistic wave patterns
-    const baseVariation = Math.sin(dayIndex * 0.8) * 2;
-    const minWave = Math.max(1, characteristics.minWave + Math.floor(baseVariation));
-    const maxWave = Math.min(characteristics.maxWave + Math.ceil(baseVariation * 1.5), 
-                            characteristics.maxWave * 1.5);
-    
-    return {
-        min: minWave,
-        max: maxWave
-    };
-}
-
-function generateCondition(waveHeight, characteristics, dayIndex) {
-    // Determine conditions based on wave height and user level
-    const avgWave = (waveHeight.min + waveHeight.max) / 2;
-    const idealRange = (characteristics.minWave + characteristics.maxWave) / 2;
-    
-    // Add some randomness for wind conditions
-    const windFactor = Math.random();
-    
-    if (windFactor < 0.2) {
-        return 'Blown Out';
-    } else if (avgWave >= idealRange - 1 && avgWave <= idealRange + 1 && windFactor > 0.7) {
+function getCondition(heightFt) {
+    const h = parseFloat(heightFt);
+    if (h >= 10) {
         return 'Epic';
-    } else if (avgWave >= characteristics.minWave && avgWave <= characteristics.maxWave && windFactor > 0.4) {
+    } else if (h >= 6) {
         return 'Firing';
-    } else {
+    } else if (h >= 3) {
         return 'Fair';
+    } else {
+        return 'Blown Out';
     }
 }
 


### PR DESCRIPTION
## Summary
- remember last selected beach alongside surf skill
- replace mock forecast generator with Open-Meteo marine API so all levels see the same data
- keep Mavericks restricted to rippers while showing forecast for other breaks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689f8a07893483269182203b72c9e106