### PR TITLE
Reorder homepage sections and update footer year

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,30 @@
             </div>
         </header>
 
+        <!-- 7-Day Forecast -->
+        <div class="forecast-container">
+            <h2 class="section-title">
+                <span class="palm">🌴</span>
+                Seven Day Swell Report
+                <span class="palm">🌴</span>
+            </h2>
+            <div id="forecast-grid" class="forecast-grid">
+                <!-- Forecast cards will be dynamically inserted here -->
+            </div>
+        </div>
+
+        <!-- Beach Selector -->
+        <div class="beach-selector">
+            <h2 class="section-title">Pick Your Break</h2>
+            <div class="beach-tabs">
+                <button class="beach-tab active" data-beach="ocean-beach">Ocean Beach</button>
+                <button class="beach-tab" data-beach="pacifica">Pacifica / Linda Mar</button>
+                <button class="beach-tab" data-beach="mavericks">Mavericks</button>
+                <button class="beach-tab" data-beach="fort-point">Fort Point</button>
+                <button class="beach-tab" data-beach="bolinas">Bolinas</button>
+            </div>
+        </div>
+
         <!-- Skill Level Selector -->
         <div class="skill-selector">
             <h2 class="section-title">What's Your Level, Brah?</h2>
@@ -40,30 +64,6 @@
                     <span class="btn-text">Ripper</span>
                     <span class="btn-desc">(Charging Everything)</span>
                 </button>
-            </div>
-        </div>
-
-        <!-- Beach Selector -->
-        <div class="beach-selector">
-            <h2 class="section-title">Pick Your Break</h2>
-            <div class="beach-tabs">
-                <button class="beach-tab active" data-beach="ocean-beach">Ocean Beach</button>
-                <button class="beach-tab" data-beach="pacifica">Pacifica / Linda Mar</button>
-                <button class="beach-tab" data-beach="mavericks">Mavericks</button>
-                <button class="beach-tab" data-beach="fort-point">Fort Point</button>
-                <button class="beach-tab" data-beach="bolinas">Bolinas</button>
-            </div>
-        </div>
-
-        <!-- 7-Day Forecast -->
-        <div class="forecast-container">
-            <h2 class="section-title">
-                <span class="palm">🌴</span>
-                Seven Day Swell Report
-                <span class="palm">🌴</span>
-            </h2>
-            <div id="forecast-grid" class="forecast-grid">
-                <!-- Forecast cards will be dynamically inserted here -->
             </div>
         </div>
 
@@ -92,7 +92,7 @@
                 Keep the Stoke Alive • No Kooks • Respect the Locals
             </p>
             <p class="footer-credit">
-                Est. 1985 in the Spirit of Aloha 🤙
+                Est. 2025 in the Spirit of Aloha 🤙
             </p>
         </footer>
     </div>


### PR DESCRIPTION
## Summary
- Move Seven Day Swell Report to top of homepage, ahead of break and skill selectors.
- Adjust section order to match desired layout.
- Update footer year from 1985 to 2025.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689f96f85e088326bf534d6c5e6a7c2f