### PR TITLE
Maintain forecast grid height during loading

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -279,6 +279,21 @@ header {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: 15px;
     margin-top: 20px;
+    transition: opacity 0.3s;
+}
+
+.forecast-grid.loading {
+    opacity: 0.5;
+}
+
+.warning-message {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 40px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    height: 100%;
 }
 
 .forecast-card {


### PR DESCRIPTION
## Summary
- Prevent layout jump by retaining forecast cards while new data loads
- Fix Mavericks warning to match forecast height and style
- Add loading state styling for forecast grid

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_b_689f9989a3788326bf6ae0d3d93dacb3